### PR TITLE
fix: support for cookieless authentication

### DIFF
--- a/backend/app/handlers/user.go
+++ b/backend/app/handlers/user.go
@@ -133,6 +133,7 @@ func LoginUser(ctx *gin.Context) {
 	http.SetCookie(ctx.Writer, cookie)
 
 	ctx.JSON(http.StatusAccepted, gin.H{
-		"userMsg": "Logged in!",
+		"userMsg":      "Logged in!",
+		"sessionToken": sessionToken,
 	})
 }

--- a/frontend/app/me/dashboard/components/create-project-form.tsx
+++ b/frontend/app/me/dashboard/components/create-project-form.tsx
@@ -34,7 +34,7 @@ export function CreateProjectForm({
   });
 
   return (
-    <Card className="p-4 w-full sm:w-96">
+    <Card className="p-0 sm:p-4 w-full sm:w-96">
       <CardHeader>
         <CardTitle>Create a project</CardTitle>
       </CardHeader>

--- a/frontend/app/me/dashboard/components/stats-section/kpi-section.tsx
+++ b/frontend/app/me/dashboard/components/stats-section/kpi-section.tsx
@@ -8,10 +8,10 @@ export interface KpiSectionProps {
 
 export function KpiSection({ projectInfo }: KpiSectionProps) {
   return (
-    <div className="p-8 space-y-4">
+    <div className="sm:p-8 p-4 space-y-4">
       <h1 className="text-2xl">KPIs for this week</h1>
 
-      <div className="flex gap-x-16">
+      <div className="sm:flex gap-x-16 space-y-6 sm:space-y-0">
         <ProgressItem
           value={projectInfo.completed}
           color="success"

--- a/frontend/lib/dashboard/fetch-user.ts
+++ b/frontend/lib/dashboard/fetch-user.ts
@@ -4,8 +4,11 @@ import { backendRoutes } from "@/config";
 import { User } from "@/lib/types/models/user";
 
 export async function getUserData(): Promise<User> {
-  const res = await axios.get(backendRoutes.user.get, {
+  const res = await axios({
+    url: backendRoutes.user.get,
+    method: "GET",
     withCredentials: true,
+    data: sessionStorage.getItem("sessionToken"),
   });
   return res.data as User;
 }

--- a/frontend/lib/login/check-auth.ts
+++ b/frontend/lib/login/check-auth.ts
@@ -1,11 +1,12 @@
-import axios from "axios";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
-import { backendRoutes, frontendRoutes } from "@/config";
+import { getUserData } from "../dashboard/fetch-user";
+
+import { frontendRoutes } from "@/config";
 
 export async function checkAuth(router: AppRouterInstance) {
   try {
-    await axios.get(backendRoutes.user.get, { withCredentials: true });
+    getUserData();
     router.push(frontendRoutes.me.dashboard);
   } catch (error) {}
 }

--- a/frontend/lib/login/on-submit.ts
+++ b/frontend/lib/login/on-submit.ts
@@ -1,10 +1,15 @@
-import axios, { AxiosError } from "axios";
+import axios from "axios";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
 import { LoginFormData } from "@/lib/types/login/form-schema";
 import { toast } from "@/components/ui/use-toast";
-import { BackendErrorResponse, backendRoutes, frontendRoutes } from "@/config";
+import { backendRoutes, frontendRoutes } from "@/config";
 import { backendErrorHandle } from "@/lib/utils/backend-error-handle";
+
+export interface LoginResponse {
+  userMsg: string;
+  sessionToken: string;
+}
 
 export async function submitLoginData(
   data: LoginFormData,
@@ -14,10 +19,12 @@ export async function submitLoginData(
     const response = await axios.post(backendRoutes.user.login, data, {
       withCredentials: true,
     });
+    const responseData = response.data as LoginResponse;
+    sessionStorage.setItem("sessionToken", responseData.sessionToken);
 
     toast({
       title: "Success!",
-      description: response.data.userMsg,
+      description: responseData.userMsg,
       variant: "success",
     });
     router.push(frontendRoutes.me.dashboard);


### PR DESCRIPTION
Sometimes on mobile and private browsing, the cookie setting gets messed up. We can now store the `sessionToken` in the local `sessionStorage`. The backend only checks it if there's no cookie.